### PR TITLE
Fix OpenAI tools and add connection test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ python -m sciresearch_ai.main run --project .\projects\my_paper `
   --reasoning-effort high `
   --temperature 0.2 --top_p 0.9 --max-output-tokens 2000 `
   --enable-code-interpreter   # optional tool
+
+# Quick check that your OpenAI API key works
+python -m sciresearch_ai.main test-openai --model gpt-4o-mini
 ```
 
 **Human control:** after each iteration, press **Enter** to continue, type text to guide, or type **stop** to end.

--- a/sciresearch_ai/main.py
+++ b/sciresearch_ai/main.py
@@ -48,6 +48,22 @@ def cmd_run(args):
     orch.run()
     print("Run finished. See state.json and logs folder for details.")
 
+def cmd_test_openai(args):
+    from .providers.openai_provider import OpenAIProvider
+    provider = OpenAIProvider(
+        model=args.model,
+        temperature=0.2,
+        top_p=1.0,
+        max_output_tokens=100,
+        reasoning_effort="low",
+        enable_code_interpreter=False,
+    )
+    try:
+        resp = provider.generate("Respond with 'OpenAI connection successful.'", n=1)[0]
+        print("OpenAI response:", resp)
+    except Exception as e:
+        print("OpenAI test failed:", e)
+
 def main(argv=None):
     p = argparse.ArgumentParser(prog="sciresearch-ai", description="Automated scientific research CLI")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -74,6 +90,10 @@ def main(argv=None):
     p_run.add_argument("--no-interactive", action="store_true", help="Disable human-in-the-loop prompts")
     p_run.add_argument("--enable-code-interpreter", action="store_true", help="Enable server-side code interpreter tool")
     p_run.set_defaults(func=cmd_run)
+
+    p_test = sub.add_parser("test-openai", help="Send a test prompt to OpenAI and print the response")
+    p_test.add_argument("--model", default="gpt-4o-mini")
+    p_test.set_defaults(func=cmd_test_openai)
 
     args = p.parse_args(argv)
     return args.func(args)

--- a/sciresearch_ai/providers/openai_provider.py
+++ b/sciresearch_ai/providers/openai_provider.py
@@ -45,60 +45,52 @@ class OpenAIProvider:
         return [
             {
                 "type": "function",
-                "function": {
-                    "name": "run_python",
-                    "description": "Execute short Python snippets and return stdout/stderr text (no network).",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "code": {"type": "string", "description": "Python code to run"}
-                        },
-                        "required": ["code"]
-                    }
+                "name": "run_python",
+                "description": "Execute short Python snippets and return stdout/stderr text (no network).",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "code": {"type": "string", "description": "Python code to run"}
+                    },
+                    "required": ["code"]
                 },
             },
             {
                 "type": "function",
-                "function": {
-                    "name": "check_symbolic_equality",
-                    "description": "Check if two mathematical expressions are symbolically equal.",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "expr1": {"type": "string"},
-                            "expr2": {"type": "string"}
-                        },
-                        "required": ["expr1","expr2"]
-                    }
+                "name": "check_symbolic_equality",
+                "description": "Check if two mathematical expressions are symbolically equal.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "expr1": {"type": "string"},
+                        "expr2": {"type": "string"}
+                    },
+                    "required": ["expr1","expr2"]
                 },
             },
             {
                 "type": "function",
-                "function": {
-                    "name": "write_project_file",
-                    "description": "Write a text file under the project folder (e.g., code/, notes/).",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "relative_path": {"type": "string", "description": "Relative path inside project, e.g., 'code/exp.py'"},
-                            "content": {"type": "string"}
-                        },
-                        "required": ["relative_path","content"]
-                    }
+                "name": "write_project_file",
+                "description": "Write a text file under the project folder (e.g., code/, notes/).",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "relative_path": {"type": "string", "description": "Relative path inside project, e.g., 'code/exp.py'"},
+                        "content": {"type": "string"}
+                    },
+                    "required": ["relative_path","content"]
                 },
             },
             {
                 "type": "function",
-                "function": {
-                    "name": "list_project_files",
-                    "description": "List files under a relative path inside the project.",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "relative_path": {"type": "string", "description": "Directory path, e.g., 'code/'"},
-                        },
-                        "required": ["relative_path"]
-                    }
+                "name": "list_project_files",
+                "description": "List files under a relative path inside the project.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "relative_path": {"type": "string", "description": "Directory path, e.g., 'code/'"},
+                    },
+                    "required": ["relative_path"]
                 },
             },
         ]
@@ -148,7 +140,7 @@ class OpenAIProvider:
         try:
             tools = self._function_tools()
             if self.enable_code_interpreter:
-                tools = [{"type": "code_interpreter"}] + tools
+                tools = [{"type": "code_interpreter", "name": "code_interpreter"}] + tools
             # We keep it simple: single prompt per call; if n>1, loop.
             if n > 1:
                 for _ in range(n):


### PR DESCRIPTION
## Summary
- fix OpenAI provider tools to include required `name` fields
- add `test-openai` CLI command for checking API connectivity
- document connectivity test in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899722bcf60832a98f71e7b178b3ac6