### PR TITLE
Expose reasoning-effort flag for OpenAI test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ python -m sciresearch_ai.main run --project .\projects\my_paper `
   --enable-code-interpreter   # optional tool
 
 # Quick check that your OpenAI API key works
-python -m sciresearch_ai.main test-openai --model gpt-4o-mini
+python -m sciresearch_ai.main test-openai --model gpt-4o-mini --reasoning-effort none
+# (or use a reasoning-capable model and omit `--reasoning-effort`)
 ```
 
 **Human control:** after each iteration, press **Enter** to continue, type text to guide, or type **stop** to end.

--- a/sciresearch_ai/main.py
+++ b/sciresearch_ai/main.py
@@ -50,12 +50,13 @@ def cmd_run(args):
 
 def cmd_test_openai(args):
     from .providers.openai_provider import OpenAIProvider
+    reasoning = None if args.reasoning_effort in (None, "none") else args.reasoning_effort
     provider = OpenAIProvider(
         model=args.model,
         temperature=0.2,
         top_p=1.0,
         max_output_tokens=100,
-        reasoning_effort="low",
+        reasoning_effort=reasoning,
         enable_code_interpreter=False,
     )
     try:
@@ -93,6 +94,7 @@ def main(argv=None):
 
     p_test = sub.add_parser("test-openai", help="Send a test prompt to OpenAI and print the response")
     p_test.add_argument("--model", default="gpt-4o-mini")
+    p_test.add_argument("--reasoning-effort", choices=["low","medium","high","none"], default=None)
     p_test.set_defaults(func=cmd_test_openai)
 
     args = p.parse_args(argv)

--- a/sciresearch_ai/providers/openai_provider.py
+++ b/sciresearch_ai/providers/openai_provider.py
@@ -27,7 +27,7 @@ class OpenAIProvider:
         temperature: float,
         top_p: float,
         max_output_tokens: int,
-        reasoning_effort: str,
+        reasoning_effort: Optional[str] = None,
         enable_code_interpreter: bool = False,
         project_root: Optional[str] = None,
     ):
@@ -147,15 +147,18 @@ class OpenAIProvider:
                     outputs.extend(self.generate(prompt, n=1, **gen_kwargs))
                 return outputs
 
-            resp = self.client.responses.create(
+            reasoning_effort = gen_kwargs.get("reasoning_effort", self.reasoning_effort)
+            params = dict(
                 model=self.model,
                 input=prompt,
                 temperature=self.temperature,
                 top_p=self.top_p,
                 max_output_tokens=self.max_output_tokens,
-                reasoning={"effort": gen_kwargs.get("reasoning_effort", self.reasoning_effort)},
                 tools=tools,
             )
+            if reasoning_effort is not None:
+                params["reasoning"] = {"effort": reasoning_effort}
+            resp = self.client.responses.create(**params)
 
             # Handle tool calling loop (function tools)
             while True:


### PR DESCRIPTION
## Summary
- allow `test-openai` CLI to accept an optional `--reasoning-effort` flag
- handle `None` reasoning effort in `OpenAIProvider`
- document quick API key test using `--reasoning-effort none`

## Testing
- `python -m pytest sciresearch_ai/testing/test_mock_flow.py sciresearch_ai/testing/test_more.py`

------
https://chatgpt.com/codex/tasks/task_b_6899ce5b396c832ab68a498ee2e783e1