### PR TITLE
feat: Add parser for LaTeX responses

### DIFF
--- a/sciresearch_ai/orchestrator.py
+++ b/sciresearch_ai/orchestrator.py
@@ -4,6 +4,7 @@ import time
 
 from .config import RunConfig
 from .inference import debate, reflection, ttc
+from .paper.parser import parse_response
 
 
 class Orchestrator:
@@ -69,7 +70,8 @@ class Orchestrator:
             # 5) Update LaTeX and autosave
             with open(pm.draft_path, "r", encoding="utf-8") as f:
                 tex = f.read()
-            new_tex = tex.replace("TBD.", methods[:2000] + "\nTBD.")
+            parsed_methods = parse_response(methods[:2000])
+            new_tex = tex.replace("TBD.", parsed_methods + "\nTBD.")
             pm.autosave(new_tex)
             ok = pm.validate_paper()
             pm.log(

--- a/sciresearch_ai/paper/parser.py
+++ b/sciresearch_ai/paper/parser.py
@@ -1,0 +1,54 @@
+import re
+
+
+def _escape_latex(text: str) -> str:
+    """Escapes special LaTeX characters in a string."""
+    chars = {
+        "&": r"\&",
+        "%": r"\%",
+        "$": r"\$",
+        "#": r"\#",
+        "_": r"\_",
+        "{": r"\{",
+        "}": r"\}",
+        "~": r"\textasciitilde{}",
+        "^": r"\^{}",
+        "\\": r"\textbackslash{}",
+    }
+    regex = re.compile("|".join(map(re.escape, chars.keys())))
+    return regex.sub(lambda match: chars[match.group(0)], text)
+
+
+def _format_code(code: str) -> str:
+    """Formats a code block for LaTeX."""
+    return f"\\begin{{verbatim}}\n{code.strip()}\n\\end{{verbatim}}"
+
+
+def parse_response(raw_text: str) -> str:
+    """Parses a raw response from the language model and formats it for LaTeX.
+
+    This function identifies code blocks (enclosed in ```) and wraps them in a
+    verbatim environment, while escaping special LaTeX characters in the
+    surrounding text.
+
+    Args:
+        raw_text: The raw string from the language model.
+
+    Returns:
+        A LaTeX-formatted string.
+    """
+    parts = []
+    last_end = 0
+    # Regex to find code blocks, optionally with a language hint
+    for match in re.finditer(r"```(\w+)?\n(.*?)```", raw_text, re.DOTALL):
+        start, end = match.span()
+        # Append the text before the code block, with escaping
+        parts.append(_escape_latex(raw_text[last_end:start]))
+        # Append the formatted code block
+        parts.append(_format_code(match.group(2)))
+        last_end = end
+
+    # Append any remaining text after the last code block, with escaping
+    parts.append(_escape_latex(raw_text[last_end:]))
+
+    return "".join(parts)

--- a/tests/paper/test_parser.py
+++ b/tests/paper/test_parser.py
@@ -1,0 +1,34 @@
+import unittest
+from sciresearch_ai.paper.parser import parse_response
+
+
+class TestParser(unittest.TestCase):
+    def test_parse_response(self):
+        raw_text = """This is a test response.
+It contains some special characters like & % $ # _ { }.
+Also, here is a code block:
+```python
+def main():
+    print("Hello, world!")
+```
+And some final text.
+"""
+        expected_output = r"""This is a test response.
+It contains some special characters like \& \% \$ \# \_ \{ \}.
+Also, here is a code block:
+\begin{verbatim}
+def main():
+    print("Hello, world!")
+\end{verbatim}
+And some final text.
+"""
+        self.assertEqual(parse_response(raw_text).strip(), expected_output.strip())
+
+    def test_escape_latex(self):
+        from sciresearch_ai.paper.parser import _escape_latex
+        self.assertEqual(_escape_latex("a&b"), r"a\&b")
+        self.assertEqual(_escape_latex("{a_b}"), r"\{a\_b\}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduces a new parser module to process raw responses from the language model before they are included in the generated LaTeX paper.

The key changes are:
- A new `sciresearch_ai/paper/parser.py` module with a `parse_response` function.
- This function escapes special LaTeX characters and wraps code blocks in a `verbatim` environment.
- The `sciresearch_ai/orchestrator.py` is updated to use this new parser on the generated content.
- Adds unit tests for the new parser to ensure its correctness.

This resolves the issue of unparsed model responses being written directly into the `.tex` files, which could lead to LaTeX compilation errors.